### PR TITLE
[HACK]Fix common utilities since load_paired_end_reads.cpp, rmap_utils.cpp are not used anywhere

### DIFF
--- a/src/common/Makefile
+++ b/src/common/Makefile
@@ -19,7 +19,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-SOURCES = $(wildcard *.cpp)
+SOURCES = $(filter-out load_paired_end_reads.cpp rmap_utils.cpp, $(wildcard *.cpp))
 OBJECTS = $(patsubst %.cpp,%.o,$(SOURCES))
 
 ifndef SMITHLAB_CPP


### PR DESCRIPTION
My write access seems to have been revoked. I am not able to push to the repo directly.